### PR TITLE
Adds JMTE-Template parsing of custom values for annotations and labels #7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+V 1.2
+-----------
+* Added JMTE-Template resolving to values for custom labels and annotations
+
 V 1.1
 -----------
 * Added release artifact to GitHub releases

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ The values `startsAt`, `endsAt` and `generatorURL` will be transmitted to the Al
 `endsAt` will be set to the point of time when the condition triggered the alert plus the set grace time which is configured for the alert.
 
 Additionally you can configure your own custom annotations and labels which should be submitted to the AlertManager (see screenshot below).
+You can use the [JMTE Template](https://cdn.rawgit.com/DJCordhose/jmte/master/doc/index.html) as you might already know from the [Graylog E-Mail Notification Callback](http://docs.graylog.org/en/2.5/pages/streams/alerts.html#email-alert-notification).
+
+List of provided keys you can use inside JMTE Templates:
+* `stream_url` - The stream url.
+* `stream` - The specific stream object. There you can use the properties of the stream object e.g. `stream.title`
+* `alertCondition` - The specific triggered alert condition. There you can use the properties of the alert condition oject e.g. `alertCondition.createdAt`
+* `check_result` - The specific check result. There you can use the properties of the check result object e.g. `check_result.triggeredAt`
+* `backlog` - A list containing messages matching the triggered condition if any. You can iterate through them with `${foreach backlog message}${message} ${end}`
+* `backlog_size` - The amount of matching messages.
 
 ## How to deploy on Graylog
 You can easily build the plugin by executing `./gradlew build -x check --no-daemon`. 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ serviceLoader {
 }
 
 group = 'de.gdata.mobilelab'
-version = 1.1
+version = 1.2
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerAlarmCallback.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerAlarmCallback.java
@@ -73,7 +73,9 @@ public class AlertManagerAlarmCallback implements AlarmCallback {
                 CONFIGURATION_KEY_CUSTOM_LABELS,
                 "Custom AlertManager labels",
                 "",
-                "The custom AlertManager label key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "' to set for each alert. Please use the following notation: 'label1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "label2=value2'",
+                "The custom AlertManager label key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR
+                        + "' to set for each alert. Please use the following notation: 'label1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR
+                        + "label2=value2"+ CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "streamtitle=${stream.title}'. You can use the JMTE-Template annotation within values of your custom labels to get live information from triggered alert.",
                 Optional.OPTIONAL
         );
         configurationRequest.addField(customLabels);
@@ -83,7 +85,9 @@ public class AlertManagerAlarmCallback implements AlarmCallback {
                 CONFIGURATION_KEY_CUSTOM_ANNOTATIONS,
                 "Custom AlertManager annotations",
                 "",
-                "The custom AlertManager annotation key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "' to set for each alert. Please use the following notation: 'annotation1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "annotation2=value2'",
+                "The custom AlertManager annotation key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR
+                        + "' to set for each alert. Please use the following notation: 'annotation1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR
+                        + "annotation2=value2" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "streamtitle=${stream.title}'. You can use the JMTE-Template annotation within values of your custom annotations to get live information from triggered alert.",
                 Optional.OPTIONAL
         );
         configurationRequest.addField(customAnnotations);

--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilder.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilder.java
@@ -1,13 +1,21 @@
 package de.gdata.mobilelab.alertmanagercallback;
 
+import com.floreysoft.jmte.Engine;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 class AlertManagerPayloadBuilder {
 
@@ -17,10 +25,12 @@ class AlertManagerPayloadBuilder {
     private AlertCondition.CheckResult checkResult;
     private Configuration configuration;
     private CustomPropertiesTextFieldParser customPropertiesTextFieldParser;
+    private Engine templateEngine;
 
     private AlertManagerPayloadBuilder() {
         // Private constructor to hide the implicit one
         customPropertiesTextFieldParser = new CustomPropertiesTextFieldParser();
+        templateEngine = new Engine();
     }
 
     static AlertManagerPayloadBuilder newInstance() {
@@ -45,7 +55,24 @@ class AlertManagerPayloadBuilder {
         return this;
     }
 
+    // parts copied from org.graylog2.alerts.FormattedEmailAlertSender#getModel()
+    private Map<String, Object> createModel(Stream stream, AlertCondition.CheckResult checkResult, List<Message> backlog) {
+        Map<String, Object> model = new HashMap<>();
+        model.put("stream", stream);
+        model.put("check_result", checkResult);
+        model.put("stream_url", extractStreamUrl());
+        model.put("alertCondition", checkResult.getTriggeredCondition());
+
+        final List<Message> messages = firstNonNull(backlog, Collections.emptyList());
+        model.put("backlog", messages);
+        model.put("backlog_size", messages.size());
+
+        return model;
+    }
+
     AlertManagerPayload build() {
+
+
         AlertManagerPayload alertManagerPayload = new AlertManagerPayload();
         alertManagerPayload.setAnnotations(extractAnnotations());
         alertManagerPayload.setLabels(extractLabels());
@@ -72,7 +99,33 @@ class AlertManagerPayloadBuilder {
             // damaged configuration, so we'll not put any additional label into the map
         }
 
+        transformTemplateValues(labels);
+
         return labels;
+    }
+
+    private void transformTemplateValues(Map<String, Object> customValueMap) {
+        customValueMap.entrySet().forEach(
+                entry -> {
+                        try {
+                            if (entry.getValue() != null) {
+                                String valueAsString = (String) entry.getValue();
+                                entry.setValue(templateEngine.transform(
+                                        valueAsString,
+                                        createModel(
+                                                stream,
+                                                checkResult,
+                                                checkResult.getMatchingMessages().stream()
+                                                        .map(MessageSummary::getRawMessage)
+                                                        .collect(Collectors.toList())
+                                        )
+                                ));
+                            }
+                        } catch (Exception ex) {
+                            // Just catch exceptions for bad formatting or direct values which should not be formatted
+                        }
+                }
+        );
     }
 
     private Map<String, Object> extractAnnotations() {
@@ -97,6 +150,8 @@ class AlertManagerPayloadBuilder {
         } catch (IOException e) {
             // damaged configuration, so we'll not put any additional annotation into the map
         }
+
+        transformTemplateValues(annotations);
 
         return annotations;
     }

--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilder.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilder.java
@@ -1,21 +1,13 @@
 package de.gdata.mobilelab.alertmanagercallback;
 
-import com.floreysoft.jmte.Engine;
-import org.graylog2.plugin.Message;
-import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
 
 class AlertManagerPayloadBuilder {
 
@@ -25,12 +17,10 @@ class AlertManagerPayloadBuilder {
     private AlertCondition.CheckResult checkResult;
     private Configuration configuration;
     private CustomPropertiesTextFieldParser customPropertiesTextFieldParser;
-    private Engine templateEngine;
 
     private AlertManagerPayloadBuilder() {
         // Private constructor to hide the implicit one
         customPropertiesTextFieldParser = new CustomPropertiesTextFieldParser();
-        templateEngine = new Engine();
     }
 
     static AlertManagerPayloadBuilder newInstance() {
@@ -39,43 +29,38 @@ class AlertManagerPayloadBuilder {
 
     AlertManagerPayloadBuilder withStream(Stream stream) {
         this.stream = stream;
-
         return this;
     }
 
     AlertManagerPayloadBuilder withCheckResult(AlertCondition.CheckResult checkResult) {
         this.checkResult = checkResult;
-
         return this;
     }
 
     AlertManagerPayloadBuilder withConfiguration(Configuration configuration) {
         this.configuration = configuration;
-
         return this;
     }
 
-    // parts copied from org.graylog2.alerts.FormattedEmailAlertSender#getModel()
-    private Map<String, Object> createModel(Stream stream, AlertCondition.CheckResult checkResult, List<Message> backlog) {
-        Map<String, Object> model = new HashMap<>();
-        model.put("stream", stream);
-        model.put("check_result", checkResult);
-        model.put("stream_url", extractStreamUrl());
-        model.put("alertCondition", checkResult.getTriggeredCondition());
-
-        final List<Message> messages = firstNonNull(backlog, Collections.emptyList());
-        model.put("backlog", messages);
-        model.put("backlog_size", messages.size());
-
-        return model;
-    }
-
     AlertManagerPayload build() {
-
-
         AlertManagerPayload alertManagerPayload = new AlertManagerPayload();
-        alertManagerPayload.setAnnotations(extractAnnotations());
-        alertManagerPayload.setLabels(extractLabels());
+
+        Map<String, Object> annotations = extractAnnotations();
+        Map<String, Object> labels = extractLabels();
+
+        // Replace template values such as '${stream.description}'
+        CustomPropertiesJMTEResolver jmteResolver = CustomPropertiesJMTEResolver.Builder.newBuilder()
+                .withCheckResult(checkResult)
+                .withStream(stream)
+                .withUrl(extractStreamUrl())
+                .build();
+
+        annotations = jmteResolver.transformTemplateValues(annotations);
+        labels = jmteResolver.transformTemplateValues(labels);
+
+        alertManagerPayload.setAnnotations(annotations);
+        alertManagerPayload.setLabels(labels);
+
         alertManagerPayload.setGeneratorURL(extractStreamUrl());
         alertManagerPayload.setStartsAt(extractStartsAt());
         alertManagerPayload.setEndsAt(extractEndsAt());
@@ -99,33 +84,7 @@ class AlertManagerPayloadBuilder {
             // damaged configuration, so we'll not put any additional label into the map
         }
 
-        transformTemplateValues(labels);
-
         return labels;
-    }
-
-    private void transformTemplateValues(Map<String, Object> customValueMap) {
-        customValueMap.entrySet().forEach(
-                entry -> {
-                        try {
-                            if (entry.getValue() != null) {
-                                String valueAsString = (String) entry.getValue();
-                                entry.setValue(templateEngine.transform(
-                                        valueAsString,
-                                        createModel(
-                                                stream,
-                                                checkResult,
-                                                checkResult.getMatchingMessages().stream()
-                                                        .map(MessageSummary::getRawMessage)
-                                                        .collect(Collectors.toList())
-                                        )
-                                ));
-                            }
-                        } catch (Exception ex) {
-                            // Just catch exceptions for bad formatting or direct values which should not be formatted
-                        }
-                }
-        );
     }
 
     private Map<String, Object> extractAnnotations() {
@@ -150,8 +109,6 @@ class AlertManagerPayloadBuilder {
         } catch (IOException e) {
             // damaged configuration, so we'll not put any additional annotation into the map
         }
-
-        transformTemplateValues(annotations);
 
         return annotations;
     }

--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPluginMetaData.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPluginMetaData.java
@@ -32,7 +32,7 @@ public class AlertManagerPluginMetaData implements PluginMetaData {
 
     @Override
     public Version getVersion() {
-        return Version.from(1, 0, 0);
+        return Version.from(1, 2, 0);
     }
 
     @Override

--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolver.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolver.java
@@ -1,0 +1,94 @@
+package de.gdata.mobilelab.alertmanagercallback;
+
+import com.floreysoft.jmte.Engine;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.streams.Stream;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class CustomPropertiesJMTEResolver {
+
+    private Engine templateEngine;
+    private Map<String, Object> templateModel;
+
+    private CustomPropertiesJMTEResolver(Map<String, Object> templateModel) {
+        templateEngine = new Engine();
+        this.templateModel = templateModel;
+    }
+
+    Map<String, Object> transformTemplateValues(Map<String, Object> customValueMap) {
+        final Map<String, Object> transformedCustomValueMap = new HashMap<>();
+        customValueMap.forEach((key, value) -> {
+            if (value instanceof String) {
+                transformedCustomValueMap.put(key, templateEngine.transform((String) value, templateModel));
+            } else {
+                transformedCustomValueMap.put(key, value);
+            }
+        });
+        return transformedCustomValueMap;
+    }
+
+    static final class Builder {
+
+        private String url;
+        private Stream stream;
+        private AlertCondition.CheckResult checkResult;
+
+        private Builder() {
+            // private constructor to hide the implicit one
+        }
+
+        static Builder newBuilder() {
+            return new Builder();
+        }
+
+        Builder withUrl(String url) {
+            this.url = url;
+            return this;
+        }
+
+        Builder withStream(Stream stream) {
+            this.stream = stream;
+            return this;
+        }
+
+        Builder withCheckResult(AlertCondition.CheckResult checkResult) {
+            this.checkResult = checkResult;
+            return this;
+        }
+
+        CustomPropertiesJMTEResolver build() {
+            return new CustomPropertiesJMTEResolver(createModel());
+        }
+
+        // parts copied from org.graylog2.alerts.FormattedEmailAlertSender#getModel()
+        private Map<String, Object> createModel() {
+
+            final Map<String, Object> model = new HashMap<>();
+            model.put("stream", stream);
+            model.put("stream_url", url);
+
+            if (checkResult != null) {
+                model.put("check_result", checkResult);
+                model.put("alertCondition", checkResult.getTriggeredCondition());
+
+                final List<Message> matchingMessages = checkResult.getMatchingMessages() != null ?
+                        checkResult.getMatchingMessages()
+                                .stream()
+                                .map(MessageSummary::getRawMessage)
+                                .collect(Collectors.toList()) :
+                        Collections.emptyList();
+                model.put("backlog", matchingMessages);
+                model.put("backlog_size", matchingMessages.size());
+            }
+
+            return model;
+        }
+    }
+}

--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolver.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolver.java
@@ -1,6 +1,7 @@
 package de.gdata.mobilelab.alertmanagercallback;
 
 import com.floreysoft.jmte.Engine;
+
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.alarms.AlertCondition;
@@ -18,7 +19,7 @@ class CustomPropertiesJMTEResolver {
     private Map<String, Object> templateModel;
 
     private CustomPropertiesJMTEResolver(Map<String, Object> templateModel) {
-        templateEngine = new Engine();
+        templateEngine = Engine.createEngine();
         this.templateModel = templateModel;
     }
 

--- a/src/test/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerAlarmCallbackTest.java
+++ b/src/test/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerAlarmCallbackTest.java
@@ -11,9 +11,7 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -75,7 +73,7 @@ public class AlertManagerAlarmCallbackTest {
         assertEquals(TextField.FIELD_TYPE, field.getFieldType());
         assertEquals("Custom AlertManager labels", field.getHumanName());
         assertEquals("", field.getDefaultValue());
-        assertEquals("The custom AlertManager label key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "' to set for each alert. Please use the following notation: 'label1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "label2=value2'", field.getDescription());
+        assertEquals("The custom AlertManager label key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "' to set for each alert. Please use the following notation: 'label1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "label2=value2" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "streamtitle=${stream.title}'. You can use the JMTE-Template annotation within values of your custom labels to get live information from triggered alert.", field.getDescription());
         assertEquals(ConfigurationField.Optional.OPTIONAL, field.isOptional());
 
         field = configurationRequest.getField("alertmanager_custom_annotations");
@@ -83,7 +81,7 @@ public class AlertManagerAlarmCallbackTest {
         assertEquals(TextField.FIELD_TYPE, field.getFieldType());
         assertEquals("Custom AlertManager annotations", field.getHumanName());
         assertEquals("", field.getDefaultValue());
-        assertEquals("The custom AlertManager annotation key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "' to set for each alert. Please use the following notation: 'annotation1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "annotation2=value2'", field.getDescription());
+        assertEquals("The custom AlertManager annotation key-value-pairs separated by '" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "' to set for each alert. Please use the following notation: 'annotation1=value1" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "annotation2=value2" + CustomPropertiesTextFieldParser.KEY_VALUE_PAIR_SEPARATOR + "streamtitle=${stream.title}'. You can use the JMTE-Template annotation within values of your custom annotations to get live information from triggered alert.", field.getDescription());
         assertEquals(ConfigurationField.Optional.OPTIONAL, field.isOptional());
     }
 

--- a/src/test/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPluginMetaDataTest.java
+++ b/src/test/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPluginMetaDataTest.java
@@ -38,7 +38,7 @@ public class AlertManagerPluginMetaDataTest {
 
     @Test
     public void getVersion() {
-        assertEquals(Version.from(1, 0, 0), new AlertManagerPluginMetaData().getVersion());
+        assertEquals(Version.from(1, 2, 0), new AlertManagerPluginMetaData().getVersion());
     }
 
     @Test

--- a/src/test/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolverTest.java
+++ b/src/test/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolverTest.java
@@ -1,0 +1,6 @@
+package de.gdata.mobilelab.alertmanagercallback;
+
+public class CustomPropertiesJMTEResolverTest {
+
+    // TODO: Add tests
+}

--- a/src/test/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolverTest.java
+++ b/src/test/java/de/gdata/mobilelab/alertmanagercallback/CustomPropertiesJMTEResolverTest.java
@@ -1,6 +1,249 @@
 package de.gdata.mobilelab.alertmanagercallback;
 
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.streams.Stream;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class CustomPropertiesJMTEResolverTest {
 
-    // TODO: Add tests
+    @Test
+    public void testBuilder() {
+        // when: building
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().build();
+
+        // then: should not be null
+        assertNotNull(customPropertiesJMTEResolver);
+    }
+
+    @Test
+    public void testBuilderWithUrl() throws Exception {
+        // given: An URL
+        String url = "https://somealertmanager.alert/";
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // when: building with given url
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().withUrl(url).build();
+        Map<String, Object> templateModel = (Map<String, Object>) templateModelField.get(customPropertiesJMTEResolver);
+
+        // then: templateModel should contain entry with URL
+        assertEquals(url, templateModel.get("stream_url"));
+    }
+
+    @Test
+    public void testBuilderWithStream() throws Exception {
+        // given: A Stream
+        Stream stream = mock(Stream.class);
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // when: building with given stream
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().withStream(stream).build();
+        Map<String, Object> templateModel = (Map<String, Object>) templateModelField.get(customPropertiesJMTEResolver);
+
+        // then: templateModel should contain entry with stream
+        assertEquals(stream, templateModel.get("stream"));
+    }
+
+    @Test
+    public void testBuilderWithCheckResult() throws Exception {
+        // given: A CheckResult
+        AlertCondition.CheckResult checkResult = mock(AlertCondition.CheckResult.class);
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // when: building with given checkResult
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().withCheckResult(checkResult).build();
+        Map<String, Object> templateModel = (Map<String, Object>) templateModelField.get(customPropertiesJMTEResolver);
+
+        // then: templateModel should contain entry with checkResult
+        assertEquals(checkResult, templateModel.get("check_result"));
+    }
+
+    @Test
+    public void testBuilderWithCheckResultContainingMessages() throws Exception {
+        // given: A CheckResult
+        AlertCondition.CheckResult checkResult = mock(AlertCondition.CheckResult.class);
+
+        // and: Message Mocks
+        Message messageOne = new Message("messageOne", "source", new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC));
+        Message messageTwo = new Message("messageTwo", "source", new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC));
+        MessageSummary messageSummaryOne = mock(MessageSummary.class);
+        MessageSummary messageSummaryTwo = mock(MessageSummary.class);
+        List<MessageSummary> messageSummaryList = Arrays.asList(messageSummaryOne, messageSummaryTwo);
+        when(messageSummaryOne.getRawMessage()).thenReturn(messageOne);
+        when(messageSummaryTwo.getRawMessage()).thenReturn(messageTwo);
+        when(checkResult.getMatchingMessages()).thenReturn(messageSummaryList);
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // when: building with given checkResult
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().withCheckResult(checkResult).build();
+        Map<String, Object> templateModel = (Map<String, Object>) templateModelField.get(customPropertiesJMTEResolver);
+
+        // then: templateModel should contain entry with checkResult
+        assertEquals(checkResult, templateModel.get("check_result"));
+
+        // and: templateModel contains those messages from above
+        assertEquals(2, templateModel.get("backlog_size"));
+        assertEquals(2, ((List<Message>) templateModel.get("backlog")).size());
+        assertTrue(((List<Message>) templateModel.get("backlog")).contains(messageOne));
+        assertTrue(((List<Message>) templateModel.get("backlog")).contains(messageTwo));
+    }
+
+    @Test
+    public void testBuilderWithCheckResultContainingNoMatchingMessages() throws Exception {
+        // given: A CheckResult which returns null as matching messages
+        AlertCondition.CheckResult checkResult = mock(AlertCondition.CheckResult.class);
+        when(checkResult.getMatchingMessages()).thenReturn(null);
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // when: building with given checkResult
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().withCheckResult(checkResult).build();
+        Map<String, Object> templateModel = (Map<String, Object>) templateModelField.get(customPropertiesJMTEResolver);
+
+        // then: templateModel should contain entry with checkResult
+        assertEquals(checkResult, templateModel.get("check_result"));
+
+        // and: templateModel contains those messages from above
+        assertEquals(0, templateModel.get("backlog_size"));
+        assertTrue(((List<Message>) templateModel.get("backlog")).isEmpty());
+    }
+
+    @Test
+    public void testBuilderWithCheckResultContainingTriggeredCondition() throws Exception {
+        // given: A CheckResult which returns a triggered condition
+        AlertCondition.CheckResult checkResult = mock(AlertCondition.CheckResult.class);
+        AlertCondition triggeredCondition = mock(AlertCondition.class);
+        when(checkResult.getTriggeredCondition()).thenReturn(triggeredCondition);
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // when: building with given checkResult
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().withCheckResult(checkResult).build();
+        Map<String, Object> templateModel = (Map<String, Object>) templateModelField.get(customPropertiesJMTEResolver);
+
+        // then: templateModel should contain entry with checkResult
+        assertEquals(checkResult, templateModel.get("check_result"));
+
+        // and: templateModel contains an alertCondition
+        assertEquals(triggeredCondition, templateModel.get("alertCondition"));
+    }
+
+    @Test
+    public void testTransformTemplateValuesWithEmptyTemplateModelMap() throws Exception {
+        // given: an empty Map
+        Map<String, Object> emptyMap = Collections.emptyMap();
+
+        // and: a CustomPropertiesJMTEResolver instance
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().build();
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // and: resolver has given map
+        templateModelField.set(customPropertiesJMTEResolver, emptyMap);
+
+        // and: A custom value map
+        Map<String, Object> customValueMap = new HashMap<>();
+        customValueMap.put("test1", "${a_unknown_key_for_template}");
+        customValueMap.put("test2", "${a_unknown_key_for_template2}sometext${another_one}");
+        customValueMap.put("test3", 1337);
+
+        // when: calling transformTemplateValues
+        Map<String, Object> result = customPropertiesJMTEResolver.transformTemplateValues(customValueMap);
+
+        // then: values which do not exist will be replaced with an empty string
+        assertTrue(result.containsKey("test1"));
+        assertTrue(result.containsKey("test2"));
+        assertTrue(result.containsKey("test3"));
+        assertEquals("", result.get("test1"));
+        assertEquals("sometext", result.get("test2"));
+        assertEquals(1337, result.get("test3"));
+    }
+
+    @Test
+    public void testTransformTemplateValuesWithCustomTemplateModelMap() throws Exception {
+        // given: a custom templateModelMap
+        Map<String, Object> customTemplateModelMap = new HashMap<>();
+        customTemplateModelMap.put("a_known_key_for_template", "bla");
+        customTemplateModelMap.put("a_known_key_for_template2", "blubb");
+        customTemplateModelMap.put("another_one", "hello");
+        customTemplateModelMap.put("backlog", Arrays.asList("Message 1: Hello", "Message2: World"));
+        customTemplateModelMap.put("existing_value", "Hello World!");
+
+        // and: a CustomPropertiesJMTEResolver instance
+        CustomPropertiesJMTEResolver customPropertiesJMTEResolver = CustomPropertiesJMTEResolver
+                .Builder.newBuilder().build();
+
+        // and: access to private field for templateModel
+        Field templateModelField = CustomPropertiesJMTEResolver.class.getDeclaredField("templateModel");
+        templateModelField.setAccessible(true);
+
+        // and: resolver has given map
+        templateModelField.set(customPropertiesJMTEResolver, customTemplateModelMap);
+
+        // and: A custom value map
+        Map<String, Object> customValueMap = new HashMap<>();
+        customValueMap.put("test1", "${a_known_key_for_template}");
+        customValueMap.put("test2", "${a_known_key_for_template2}sometext${another_one}");
+        customValueMap.put("test3", 1337);
+        customValueMap.put("test4", "${an_unknown_key_for_template}");
+        customValueMap.put("foreachTest", "${foreach backlog message}${message} ${end}");
+        customValueMap.put("ifTest", "${if not_existing_value}${not_existing_value}${else}unknown${end}");
+        customValueMap.put("ifTest2", "${if existing_value}${existing_value}${else}unknown${end}");
+
+        // when: calling transformTemplateValues
+        Map<String, Object> result = customPropertiesJMTEResolver.transformTemplateValues(customValueMap);
+
+        // then: values should be replaced if they exist inside the templateModelMap
+        assertTrue(result.containsKey("test1"));
+        assertTrue(result.containsKey("test2"));
+        assertTrue(result.containsKey("test3"));
+        assertTrue(result.containsKey("test4"));
+        assertTrue(result.containsKey("foreachTest"));
+        assertTrue(result.containsKey("ifTest"));
+        assertTrue(result.containsKey("ifTest2"));
+        assertEquals("bla", result.get("test1"));
+        assertEquals("blubbsometexthello", result.get("test2"));
+        assertEquals(1337, result.get("test3"));
+        assertEquals("", result.get("test4"));
+        assertEquals("Message 1: Hello Message2: World ", result.get("foreachTest"));
+        assertEquals("unknown", result.get("ifTest"));
+        assertEquals("Hello World!", result.get("ifTest2"));
+    }
+
 }


### PR DESCRIPTION
This changes makes the users able to use JMTE-Templates as in the default Graylog E-Mail Notification Callback as requested in issue #7 .