### PR TITLE
fix flapping alerts in Alertmanager

### DIFF
--- a/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilder.java
+++ b/src/main/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilder.java
@@ -118,7 +118,16 @@ class AlertManagerPayloadBuilder {
             return new DateTime().plusMinutes(1).toString();
         }
 
-        return checkResult.getTriggeredAt().plusMinutes(checkResult.getTriggeredCondition().getGrace()).toString();
+        int delay = checkResult.getTriggeredCondition().getGrace();
+
+        // when grace is 0, the next alert isn't for another minute
+        if(delay == 0) {
+            delay += 1;
+        }
+
+        // give a small window to avoid alerts expiring due to the notification
+        // not being sent exactly on time
+        return checkResult.getTriggeredAt().plusMinutes(delay).plusSeconds(10).toString();
     }
 
     private String extractStartsAt() {

--- a/src/test/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilderTest.java
+++ b/src/test/java/de/gdata/mobilelab/alertmanagercallback/AlertManagerPayloadBuilderTest.java
@@ -157,7 +157,7 @@ public class AlertManagerPayloadBuilderTest {
         assertEquals(triggeredAt.toString(), alertManagerPayload.getStartsAt());
 
         // - endsAt
-        assertEquals(triggeredAt.plusMinutes(1337).toString(), alertManagerPayload.getEndsAt());
+        assertEquals(triggeredAt.plusMinutes(1337).plusSeconds(10).toString(), alertManagerPayload.getEndsAt());
 
         // - generatorUrl
         assertEquals("aStreamUrl", alertManagerPayload.getGeneratorURL());
@@ -216,6 +216,8 @@ public class AlertManagerPayloadBuilderTest {
         AlertCondition alertCondition = mock(AlertCondition.class);
         when(alertCondition.getGrace()).thenReturn(0);
         when(checkResult.getTriggeredCondition()).thenReturn(alertCondition);
+        DateTime triggeredAt = new DateTime();
+        when(checkResult.getTriggeredAt()).thenReturn(triggeredAt);
 
         // and: instance with set mocks as values
         AlertManagerPayload alertManagerPayload = AlertManagerPayloadBuilder.newInstance()
@@ -226,6 +228,7 @@ public class AlertManagerPayloadBuilderTest {
         // - endsAt
         assertNotNull(alertManagerPayload.getEndsAt());
         assertNotEquals("", alertManagerPayload.getEndsAt());
+        assertEquals(triggeredAt.plusMinutes(1).plusSeconds(10).toString(), alertManagerPayload.getEndsAt());
     }
 
     @Test


### PR DESCRIPTION
- If startsAt and endsAt are equal, Alertmanager will mark the alert as
  resolved.  This is the case when the grace period is set to 0 for an
  alert condition.

- Alertmanager will prune alerts when it hits the time specified in the
  endsAt field.  Graylog is good at sending notifications on time, but
  a small window is added in case there is a delay will prevent alerts
  going stale.

We can see that the `endsAt` field is now correctly set:
```
  {
    "annotations": {
      "stream_title": "All messages",
      "triggered_at": "2019-08-17T22:57:35.689Z",
      "triggered_rule_description": "time: 1, threshold_type: more, threshold: 1, grace: 0, repeat notifications: true",
      "triggered_rule_title": "test"
    },
    "endsAt": "2019-08-17T22:58:45.689Z",
    "fingerprint": "e694db4ece012afd",
    "receivers": [
      {
        "name": "mattermost"
      }
    ],
    "startsAt": "2019-08-17T22:57:35.689Z",
    "status": {
      "inhibitedBy": [],
      "silencedBy": [],
      "state": "active"
    },
    "updatedAt": "2019-08-17T22:57:35.771Z",
    "generatorURL": "null",
    "labels": {
      "alertname": "test",
      "job": "test",
      "severity": "warning",
      "streamtitle": "All messages"
    }
  }
```

And Graylog sends the alerts before the alert expires:
```
2019-08-17 22:57:35.689
Graylog checks test (Message Count Alert Condition) condition on stream All messages
2019-08-17 22:57:35.689
Stream had 252 messages in the last 1 minutes with trigger condition more than 1 messages. (Current grace time: 0 minutes)
2019-08-17 22:57:35.689
Graylog triggers an alert for test (Message Count Alert Condition) and starts sending notifications2019-08-17 22:57:35.784
Graylog sent All messages-alertmanager (AlertManager Callback) notification2019-08-17 22:58:35.706
Graylog sent All messages-alertmanager (AlertManager Callback) notification2019-08-17 22:59:35.772
Graylog sent All messages-alertmanager (AlertManager Callback) notification2019-08-17 22:59:45.426
Condition is configured to repeat notifications, Graylog will send notifications when evaluating the condition until it is no longer satisfied
2019-08-17 22:59:45.426
Condition is still satisfied, alert is unresolved
```

Fixes https://github.com/GDATASoftwareAG/Graylog-Plugin-AlertManager-Callback/issues/9